### PR TITLE
feat(pages): Add basic layout and components

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,6 +6,7 @@
       "name": "civicsphere",
       "dependencies": {
         "@fluentui/react-components": "^9.72.7",
+        "@fluentui/react-icons": "^2.0.315",
         "next": "16.0.3",
         "react": "19.2.0",
         "react-dom": "19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fluentui/react-components": "^9.72.7",
+    "@fluentui/react-icons": "^2.0.315",
     "next": "16.0.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,26 +1,9 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+* {
+    box-sizing: border-box;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+.surround {
+    @apply p-5 md:p-8 lg:p-10;
 }

--- a/frontend/src/app/home/page.tsx
+++ b/frontend/src/app/home/page.tsx
@@ -1,7 +1,32 @@
+'use client'
+import SideBar from '@/lib/components/SideBar';
+import { Avatar, Hamburger, Tooltip } from '@fluentui/react-components';
+import { useState } from 'react';
+
 export default function Page() {
+  const userName = 'Dummy Name'
+  const [isNavOpen, setNavOpen] = useState(false)
   return (
-    <>
-      <h1>Home Page</h1>
-    </>
+    <div className='bg-gray-200 min-h-screen flex flex-col'>
+      <SideBar isNavOpen={isNavOpen} setNavOpen={setNavOpen} />
+      <div className='flex justify-between p-3 lg:p-5 xl:p-8 border'>
+        <Tooltip
+          content="Open Navigation bar"
+          relationship="label"
+          positioning="after"
+        >
+          <Hamburger onClick={() => setNavOpen(true)} />
+        </Tooltip>
+        <Avatar name={userName} activeAppearance='ring-shadow' active='active' color='platinum' />
+      </div>
+      <div className='border mx-auto min-w-4xl h-full'>
+        <div className='flex flex-col p-3 lg:p-5 xl:p-8'>
+          <h1 className='text-xl lg:text-2xl font-semibold'>Welcome back!</h1>
+          <div className='bg-radial bg-clip-text from-blue-500 to-green-500'>
+            <p className='font-extrabold text-2xl lg:text-4xl text-transparent text-clip'>{userName}</p>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,6 @@
+import AppContainer from "@/lib/components/AppContainer";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,10 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body>
+        <AppContainer>
+          {children}
+        </AppContainer>
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,65 +1,55 @@
-import Image from "next/image";
+'use client'
+
+import { Button } from "@fluentui/react-components";
+
+type Feature = {
+  title: string;
+  description: string;
+}
+
+const features: Feature[] = [
+  {
+    title: "Title 1",
+    description: "Description for feature 1.",
+  },
+  {
+    title: "Title 2",
+    description: "Description for feature 2.",
+  },
+  {
+    title: "Title 3",
+    description: "Description for feature 3.",
+  },
+]
 
 export default function Home() {
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
+    <>
+      <div className="mx-auto min-h-screen flex flex-col justify-center items-center gap-3 md:gap-5 lg:gap-8">
+        <div>
+          {/* Logo */}
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
+        <div className="flex flex-col gap-3 items-center">
+          <h1 className="text-3xl font-bold">CivicSphere</h1>
+          <p className="text-lg lg:text-xl">Welcome to CivicSphere, a platform for civic engagement and community collaboration.</p>
+          <div className="flex gap-3">
+            <Button appearance="primary" as="a" href="/auth?action=signup">Get Started</Button>
+            <Button appearance="outline" as="a" href="/auth?action=signin">Sign In</Button>
+          </div>
         </div>
-      </main>
-    </div>
-  );
+        {/* Features Section */}
+        <div className="flex flex-col gap-3 items-center">
+          <div className="flex md:flex-row gap-3 lg:gap-9">
+            {features.map((feature, index) => (
+              <div key={index} className="flex flex-col gap-3 p-3 md:p-5 rounded-xl shadow-xl border border-gray-200">
+                <h3 className="font-bold text-xl text-center">{feature.title}</h3>
+                <p className="text-lg text-justify">{feature.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
 }

--- a/frontend/src/lib/components/SideBar.tsx
+++ b/frontend/src/lib/components/SideBar.tsx
@@ -1,0 +1,114 @@
+'use client'
+import { Hamburger, NavDrawer, NavDrawerBody, NavDrawerFooter, NavDrawerHeader, NavItem, Tooltip } from "@fluentui/react-components"
+import { ArrowTrendingLinesFilled, HomeRegular, PeopleCommunityRegular, SettingsRegular } from "@fluentui/react-icons"
+import { ChatSparkleRegular } from "@fluentui/react-icons/svg/chat-sparkle"
+import { Dispatch, SetStateAction } from "react"
+
+const SideBar = ({ isNavOpen, setNavOpen }: { isNavOpen: boolean, setNavOpen: Dispatch<SetStateAction<boolean>> }) => {
+  return (
+    <>
+      <NavDrawer
+        open={isNavOpen}
+      >
+        <NavDrawerHeader className="border-b border-b-gray-400 bg-gray-300">
+          <div className="py-3">
+            <Tooltip
+              content="Close Navigation bar"
+              relationship="label"
+              positioning="after"
+            >
+              <Hamburger onClick={() => setNavOpen(false)} />
+            </Tooltip>
+
+          </div>
+        </NavDrawerHeader>
+        <NavDrawerBody className="flex flex-col justify-start">
+          <div className="py-3">
+            <NavItem
+              icon={
+                <span className="text-2xl" >
+                  <HomeRegular />
+                </span>
+              }
+              href="/home"
+              value="1"
+              aria-label="Home button"
+              className="border"
+            >
+              <span className="py-1 font-semibold text-lg">
+                Home
+              </span>
+            </NavItem>
+            <NavItem
+              icon={
+                <span className="text-2xl" >
+                  <ArrowTrendingLinesFilled />
+                </span>
+              }
+              href="/trending"
+              value="2"
+              aria-label="Trending button"
+              className="border"
+            >
+              <span className="py-1 font-semibold text-lg">
+                Trending
+              </span>
+            </NavItem>
+            <NavItem
+              icon={
+                <span className="text-2xl" >
+                  <ChatSparkleRegular />
+                </span>
+              }
+              href="/chat"
+              value="3"
+              aria-label="Chat button"
+              className="border"
+            >
+              <span className="py-1 font-semibold text-lg">
+                Chat
+              </span>
+            </NavItem>
+            <NavItem
+              icon={
+                <span className="text-2xl" >
+                  <PeopleCommunityRegular />
+                </span>
+              }
+              href="/home"
+              value="4"
+              aria-label="Community button"
+              className="border"
+            >
+              <span className="py-1 font-semibold text-lg">
+                Community
+              </span>
+            </NavItem>
+            <NavItem
+              icon={
+                <span className="text-2xl" >
+                  <SettingsRegular />
+                </span>
+              }
+              href="/home"
+              value="5"
+              aria-label="Settings button"
+              className="border"
+            >
+              <span className="py-1 font-semibold text-lg">
+                Settings
+              </span>
+            </NavItem>
+          </div>
+        </NavDrawerBody>
+        <NavDrawerFooter className="border-t border-t-gray-400 bg-gray-300">
+          <div className="text-sm italic p-3">
+            © 2025 CivicSphere
+          </div>
+        </NavDrawerFooter>
+      </NavDrawer>
+    </>
+  )
+}
+
+export default SideBar


### PR DESCRIPTION
This PR adds,
- a very simple and basic layout for pages
<img width="1840" height="869" alt="image" src="https://github.com/user-attachments/assets/56dbc5fd-68cd-4dc8-b967-89be73778e03" />

- Sidebar component
<img width="1839" height="946" alt="image" src="https://github.com/user-attachments/assets/da7fe18c-0bed-4415-9f21-c61c7a0d75c2" />
